### PR TITLE
Improve discovery

### DIFF
--- a/machine/asic/discovery.go
+++ b/machine/asic/discovery.go
@@ -26,6 +26,7 @@ func DiscoverByIPScan(ctx context.Context, networks []string, portBegin int, por
 		if err != nil {
 			continue
 		}
+		arp.CacheUpdate()
 		for _, r := range ret {
 			// Collect mac addr from ARP table
 			mac := arp.Search(r.IP)
@@ -68,6 +69,8 @@ func DiscoverByMCast(ctx context.Context, mcastCode string, mcastAddr string, mc
 		return err
 	}
 	defer conn.Close()
+
+	arp.CacheUpdate()
 
 	deadline := time.Now().Add(timeout)
 	conn.SetReadBuffer(bufSize)

--- a/machine/asic/discovery.go
+++ b/machine/asic/discovery.go
@@ -11,6 +11,7 @@ import (
 	"github.com/miekg/dns"
 
 	"github.com/ka2n/masminer/machine"
+	nettool "github.com/ka2n/masminer/net"
 	"github.com/ka2n/masminer/netscan"
 	"github.com/mostlygeek/arp"
 )
@@ -30,7 +31,7 @@ func DiscoverByIPScan(ctx context.Context, networks []string, portBegin int, por
 			mac := arp.Search(r.IP)
 
 			var rig machine.RemoteRig
-			if mac != "" {
+			if nettool.ValidateMAC(mac) {
 				rig.Name = machine.ShortName(mac)
 				rig.MACAddr = mac
 			}
@@ -94,10 +95,10 @@ func DiscoverByMCast(ctx context.Context, mcastCode string, mcastAddr string, mc
 				if len(ans) > 3 && len(ans[3]) > 0 {
 					mac = ans[3]
 				}
-				if mac == "" {
-					continue
+				if nettool.ValidateMAC(mac) {
+					rig.Name = machine.ShortName(mac)
+					rig.MACAddr = mac
 				}
-				rig.Name = mac
 				rig.IPAddr = src.IP.String()
 				rig.Hostname = netscan.LookupHostname(dnsClient, rig.IPAddr)
 				handler(rig)

--- a/net/mac.go
+++ b/net/mac.go
@@ -1,0 +1,26 @@
+package net
+
+import (
+	"net"
+)
+
+// ValidateMAC validates a address is hardware address
+func ValidateMAC(mac string) bool {
+	addr, err := net.ParseMAC(mac)
+	if err != nil {
+		return false
+	}
+
+	isBroadcast := (addr[0] >> 0 & 1) == 1
+	if isBroadcast {
+		return false
+	}
+
+	// Check if all zero: 00:00:00:00:00:00
+	for _, b := range addr {
+		if b != 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/net/mac_test.go
+++ b/net/mac_test.go
@@ -1,0 +1,28 @@
+package net
+
+import "testing"
+
+func TestValidateMAC(t *testing.T) {
+	type args struct {
+		mac string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"Empty", args{""}, false},
+		{"Zero", args{"00:00:00:00:00:00"}, false},
+		{"Broadcast", args{"FF:FF:FF:FF:FF:FF"}, false},
+		{"IPv4 multicast", args{"01:00:5E:00:00:00"}, false},
+		{"IPv6 multicast", args{"33:33:00:00:00:00"}, false},
+		{"Valid example mac address", args{"32:61:3C:4E:B6:05"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateMAC(tt.args.mac); got != tt.want {
+				t.Errorf("ValidateMAC() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add MAC Address validation and clean ARP cache each time after scanning new device process.